### PR TITLE
Fix env variable name for mongo cacert in deployment

### DIFF
--- a/chart/mob-assist-api/templates/deployment.yaml
+++ b/chart/mob-assist-api/templates/deployment.yaml
@@ -54,7 +54,7 @@ spec:
                 secretKeyRef:
                   name: mongodb-config
                   key: password
-            - name: MONGODB_CERT_BASE64
+            - name: MONGODB_CACERT_BASE64
               valueFrom:
                 secretKeyRef:
                   name: mongodb-config

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,11 +11,11 @@ spring:
 
   data:
     mongodb:
-      uri: "${MONGODB_URI:}"
-      database: "${MONGODB_DATABASE:}"
-      username: "${MONGODB_USERNAME:}"
-      password: "${MONGODB_PASSWORD:}"
-      ca-cert-base64: "${MONGODB_CACERT_BASE64:}"
+      uri: "${MONGODB_URI}"
+      database: "${MONGODB_DATABASE}"
+      username: "${MONGODB_USERNAME}"
+      password: "${MONGODB_PASSWORD}"
+      ca-cert-base64: "${MONGODB_CACERT_BASE64}"
 
 twilio:
   accountSid: "${TWILIO_ACCOUNT_SID}"


### PR DESCRIPTION
closes #16 