### PR TITLE
Fix Twilio webhook media type error

### DIFF
--- a/src/main/java/com/dex/mobassist/server/controllers/TwilioWebhookController.java
+++ b/src/main/java/com/dex/mobassist/server/controllers/TwilioWebhookController.java
@@ -29,7 +29,7 @@ public class TwilioWebhookController {
             produces = {MediaType.APPLICATION_XML_VALUE}
     )
     @ResponseBody
-    public String twilioMessageWebhook(@RequestBody TwilioWebhookRequestCargo request) {
+    public String twilioMessageWebhook(TwilioWebhookRequestCargo request) {
         System.out.println("Got message: " + request);
 
         return service.handleMessageWebhook(request).toXml();


### PR DESCRIPTION
- Remove @RequestBody from method signature - closes #22 