### PR TITLE
Fix text message notification problems

### DIFF
--- a/src/main/java/com/dex/mobassist/server/service/twilio/AssignmentMessageSender.java
+++ b/src/main/java/com/dex/mobassist/server/service/twilio/AssignmentMessageSender.java
@@ -37,7 +37,8 @@ public class AssignmentMessageSender extends AbstractMemberSignupResponseMessage
 
     @Override
     protected Predicate<MemberSignupResponse> filterMessage() {
-        return (MemberSignupResponse response) -> !Boolean.TRUE.equals(loadSignupOption(response.getSelectedOption()).getDeclineOption());
+        return (MemberSignupResponse response) -> response.getSelectedOption() != null
+                && !Boolean.TRUE.equals(loadSignupOption(response.getSelectedOption()).getDeclineOption());
     }
 
     @Override
@@ -105,6 +106,6 @@ public class AssignmentMessageSender extends AbstractMemberSignupResponseMessage
     }
 
     protected String getMessageSuffix() {
-        return "Reply STOP to end messages or HELP for more options.";
+        return "Reply STOP to unsubscribe or OPTIONS for more options.";
     }
 }

--- a/src/main/java/com/dex/mobassist/server/service/twilio/CheckinRequestMessageSender.java
+++ b/src/main/java/com/dex/mobassist/server/service/twilio/CheckinRequestMessageSender.java
@@ -28,7 +28,8 @@ public class CheckinRequestMessageSender extends AbstractMemberSignupResponseMes
 
     @Override
     protected Predicate<MemberSignupResponse> filterMessage() {
-        return (MemberSignupResponse response) -> !Boolean.TRUE.equals(loadSignupOption(response.getSelectedOption()).getDeclineOption());
+        return (MemberSignupResponse response) -> response.getSelectedOption() != null
+                && !Boolean.TRUE.equals(loadSignupOption(response.getSelectedOption()).getDeclineOption());
     }
 
     @Override
@@ -37,7 +38,7 @@ public class CheckinRequestMessageSender extends AbstractMemberSignupResponseMes
             final String message = format(
                     "%s. %s",
                     buildAssignmentMessage(signup, loadSignupOption(response.getSelectedOption()), loadAssignments(response.getAssignments())),
-                    "Reply YES to checkin, NO if you are unable to serve or STOP to end messages.");
+                    "Reply YES to checkin, NO if you are unable to serve or STOP to unsubscribe.");
 
             return creator(
                     new PhoneNumber(response.getMember().getId()),

--- a/src/main/java/com/dex/mobassist/server/service/twilio/SignupRequestMessageSender.java
+++ b/src/main/java/com/dex/mobassist/server/service/twilio/SignupRequestMessageSender.java
@@ -46,7 +46,7 @@ public class SignupRequestMessageSender extends AbstractMemberSignupResponseMess
     }
 
     protected String getMessageSuffix() {
-        return "Reply STOP to end messages or HELP for more options.";
+        return "Reply STOP to unsubscribe or OPTIONS for more options.";
     }
 
     protected String buildSignupConfirmMessage(Signup signup, List<? extends SignupOption> options, SignupOption selectedOption) {

--- a/src/main/java/com/dex/mobassist/server/service/twilio/SignupRequestNoResponseMessageSender.java
+++ b/src/main/java/com/dex/mobassist/server/service/twilio/SignupRequestNoResponseMessageSender.java
@@ -44,7 +44,7 @@ public class SignupRequestNoResponseMessageSender extends AbstractMemberSignupRe
     }
 
     protected String getMessageSuffix() {
-        return "Reply STOP to end messages or HELP for more options.";
+        return "Reply STOP to unsubscribe or OPTIONS for more options.";
     }
 
     protected String buildSignupConfirmMessage(Signup signup, List<? extends SignupOption> options, SignupOption selectedOption) {


### PR DESCRIPTION
- Change HELP to OPTIONS to avoid Twilio key word
- Change language of STOP to say "unsubscribe"
- Change signup options to upper case, to optionally include decline option, and include "or" separator
- Fix assignment and checkin notification filter to exclude no response members from notification